### PR TITLE
Add missing INTERACTIONS_QUEUE to FA

### DIFF
--- a/resources/arm/wf-price-butler.json
+++ b/resources/arm/wf-price-butler.json
@@ -218,6 +218,10 @@
                         {
                             "name": "SERVICE_BUS",
                             "value": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', concat(parameters('sbName'), '-', parameters('envName')), parameters('sbAuthRuleName')), '2017-04-01').primaryConnectionString]"
+                        },
+                        {
+                            "name": "INTERACTIONS_QUEUE",
+                            "value": "[parameters('sbInteractionsQueueName')]"
                         }
                     ]
                 }


### PR DESCRIPTION
Fix ARM template by adding the `INTERACTIONS_QUEUE` config setting to the function apps deployed by it.