### PR TITLE
Add smarter deployment triggers

### DIFF
--- a/.github/workflows/arm.yaml
+++ b/.github/workflows/arm.yaml
@@ -1,4 +1,4 @@
-name: Deploy infrastructure
+name: infrastructure
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy
+name: deploy
 
 on:
   workflow_call:
@@ -21,6 +21,7 @@ on:
         required: true
 
 env:
+  CARGO_TERM_COLOR: always
   CARGO_BUILD_ARGS: --release --verbose
 
 permissions:

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,8 +1,13 @@
-name: Deploy (dev)
+name: deploy-dev
 
 on:
   push:
     branches: [dev]
+  workflow_dispatch:
+  workflow_run:
+    workflows: [infrastructure]
+    types: [completed]
+    branches: [prod]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -9,9 +9,6 @@ on:
     types: [completed]
     branches: [prod]
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yaml

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -1,12 +1,13 @@
-name: Deploy (prod)
+name: deploy-prod
 
 on:
   push:
     branches: [prod]
-
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_BUILD_ARGS: --release --verbose
+  workflow_dispatch:
+  workflow_run:
+    workflows: [infrastructure]
+    types: [completed]
+    branches: [prod]
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds triggers for code deployments based on either a manual trigger or after the infrastructure is deployed. This way an infrastructure deployment is always immediately followed by a code deployment.