### PR TITLE
Fix trigger in dev deployment

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -7,7 +7,7 @@ on:
   workflow_run:
     workflows: [infrastructure]
     types: [completed]
-    branches: [prod]
+    branches: [dev]
 
 jobs:
   deploy:


### PR DESCRIPTION
Changes the branch a trigger in the dev deployment workflow references to the `dev` branch instead of the `prod` branch.